### PR TITLE
Move add button

### DIFF
--- a/app/src/main/java/be/huffle/allowanceplanner/activities/AddAllowanceActivity.java
+++ b/app/src/main/java/be/huffle/allowanceplanner/activities/AddAllowanceActivity.java
@@ -31,7 +31,6 @@ public class AddAllowanceActivity extends AppCompatActivity
 		setContentView(R.layout.activity_add);
 
 		ActionBar actionBar = getSupportActionBar();
-		//Button addButton = findViewById(R.id.add_button);
 		amountEditText = findViewById(R.id.amount_input);
 		descriptionEditText = findViewById(R.id.description_input);
 		sharedPreferences = getApplicationContext().getSharedPreferences("SharedPref", MODE_PRIVATE);
@@ -39,8 +38,6 @@ public class AddAllowanceActivity extends AppCompatActivity
 
 		actionBar.setDisplayHomeAsUpEnabled(true);
 		actionBar.setTitle("Add Allowance");
-
-		//addButton.setOnClickListener(this);
 	}
 
 	@Override
@@ -57,11 +54,13 @@ public class AddAllowanceActivity extends AppCompatActivity
 				if (amountText.isEmpty())
 				{
 					showDialog("Amount needs to be filled out");
-					return true;
+				}
+				else
+				{
+					addAllowance(Float.valueOf(amountEditText.getText().toString()),
+							descriptionEditText.getText().toString());
 				}
 
-				addAllowance(Float.valueOf(amountEditText.getText().toString()),
-						descriptionEditText.getText().toString());
 				return true;
 			default:
 				return super.onOptionsItemSelected(item);

--- a/app/src/main/java/be/huffle/allowanceplanner/activities/AddAllowanceActivity.java
+++ b/app/src/main/java/be/huffle/allowanceplanner/activities/AddAllowanceActivity.java
@@ -9,6 +9,7 @@ import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.*;
 import android.os.Bundle;
+import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
@@ -16,7 +17,7 @@ import android.widget.EditText;
 
 import be.huffle.allowanceplanner.R;
 
-public class AddAllowanceActivity extends AppCompatActivity implements View.OnClickListener
+public class AddAllowanceActivity extends AppCompatActivity
 {
 	private SharedPreferences sharedPreferences;
 	private Editor editor;
@@ -30,7 +31,7 @@ public class AddAllowanceActivity extends AppCompatActivity implements View.OnCl
 		setContentView(R.layout.activity_add);
 
 		ActionBar actionBar = getSupportActionBar();
-		Button addButton = findViewById(R.id.add_button);
+		//Button addButton = findViewById(R.id.add_button);
 		amountEditText = findViewById(R.id.amount_input);
 		descriptionEditText = findViewById(R.id.description_input);
 		sharedPreferences = getApplicationContext().getSharedPreferences("SharedPref", MODE_PRIVATE);
@@ -39,40 +40,40 @@ public class AddAllowanceActivity extends AppCompatActivity implements View.OnCl
 		actionBar.setDisplayHomeAsUpEnabled(true);
 		actionBar.setTitle("Add Allowance");
 
-		addButton.setOnClickListener(this);
+		//addButton.setOnClickListener(this);
 	}
 
 	@Override
 	public boolean onOptionsItemSelected(@NonNull MenuItem item)
 	{
-		int id = item.getItemId();
-
-		if (id == android.R.id.home)
+		switch (item.getItemId())
 		{
-			finish();
-		}
-
-		return true;
-	}
-
-	@Override
-	public void onClick(View view)
-	{
-		switch (view.getId())
-		{
-			case R.id.add_button:
+			case android.R.id.home:
+				finish();
+				return true;
+			case R.id.add_menu_button:
 				String amountText = amountEditText.getText().toString();
 
 				if (amountText.isEmpty())
 				{
 					showDialog("Amount needs to be filled out");
-					break;
+					return true;
 				}
 
-				addAllowance(Float.valueOf(amountText),
+				addAllowance(Float.valueOf(amountEditText.getText().toString()),
 						descriptionEditText.getText().toString());
-			break;
+				return true;
+			default:
+				return super.onOptionsItemSelected(item);
+
 		}
+	}
+
+	@Override
+	public boolean onCreateOptionsMenu(Menu menu)
+	{
+		getMenuInflater().inflate(R.menu.add_menu, menu);
+		return super.onCreateOptionsMenu(menu);
 	}
 
 	private void showDialog(String message)

--- a/app/src/main/java/be/huffle/allowanceplanner/activities/AddExpenseActivity.java
+++ b/app/src/main/java/be/huffle/allowanceplanner/activities/AddExpenseActivity.java
@@ -54,11 +54,13 @@ public class AddExpenseActivity extends AppCompatActivity
 				if (amountText.isEmpty())
 				{
 					showDialog("Amount needs to be filled out");
-					return true;
+				}
+				else
+				{
+					tryAddExpense(Float.valueOf(amountEditText.getText().toString()),
+							descriptionEditText.getText().toString());
 				}
 
-				tryAddExpense(Float.valueOf(amountEditText.getText().toString()),
-						descriptionEditText.getText().toString());
 				return true;
 			default:
 				return super.onOptionsItemSelected(item);

--- a/app/src/main/java/be/huffle/allowanceplanner/activities/AddExpenseActivity.java
+++ b/app/src/main/java/be/huffle/allowanceplanner/activities/AddExpenseActivity.java
@@ -9,6 +9,7 @@ import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.*;
 import android.os.Bundle;
+import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
@@ -16,7 +17,7 @@ import android.widget.EditText;
 
 import be.huffle.allowanceplanner.R;
 
-public class AddExpenseActivity extends AppCompatActivity implements View.OnClickListener
+public class AddExpenseActivity extends AppCompatActivity
 {
 	private SharedPreferences sharedPreferences;
 	private Editor editor;
@@ -30,7 +31,6 @@ public class AddExpenseActivity extends AppCompatActivity implements View.OnClic
 		setContentView(R.layout.activity_add);
 
 		ActionBar actionBar = getSupportActionBar();
-		Button addButton = findViewById(R.id.add_button);
 		amountEditText = findViewById(R.id.amount_input);
 		descriptionEditText = findViewById(R.id.description_input);
 		sharedPreferences = getApplicationContext().getSharedPreferences("SharedPref", MODE_PRIVATE);
@@ -38,41 +38,39 @@ public class AddExpenseActivity extends AppCompatActivity implements View.OnClic
 
 		actionBar.setDisplayHomeAsUpEnabled(true);
 		actionBar.setTitle("Add Expense");
-
-		addButton.setOnClickListener(this);
 	}
 
 	@Override
 	public boolean onOptionsItemSelected(@NonNull MenuItem item)
 	{
-		int id = item.getItemId();
-
-		if (id == android.R.id.home)
+		switch (item.getItemId())
 		{
-			finish();
-		}
-
-		return true;
-	}
-
-	@Override
-	public void onClick(View view)
-	{
-		switch (view.getId())
-		{
-			case R.id.add_button:
+			case android.R.id.home:
+				finish();
+				return true;
+			case R.id.add_menu_button:
 				String amountText = amountEditText.getText().toString();
 
 				if (amountText.isEmpty())
 				{
 					showDialog("Amount needs to be filled out");
-					break;
+					return true;
 				}
-				
+
 				tryAddExpense(Float.valueOf(amountEditText.getText().toString()),
 						descriptionEditText.getText().toString());
-			break;
+				return true;
+			default:
+				return super.onOptionsItemSelected(item);
+
 		}
+	}
+
+	@Override
+	public boolean onCreateOptionsMenu(Menu menu)
+	{
+		getMenuInflater().inflate(R.menu.add_menu, menu);
+		return super.onCreateOptionsMenu(menu);
 	}
 
 	private void showDialog(String message)

--- a/app/src/main/res/layout/activity_add.xml
+++ b/app/src/main/res/layout/activity_add.xml
@@ -5,7 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".activities.AddAllowanceActivity">
-
     <TextView
         android:id="@+id/amount_textView"
         android:layout_width="wrap_content"
@@ -47,19 +46,8 @@
         android:layout_marginStart="32dp"
         android:ems="10"
         android:inputType="textMultiLine|text"
-        app:layout_constraintBottom_toTopOf="@+id/add_button"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/amount_textView2"
         app:layout_constraintVertical_bias="0.0"
         android:maxHeight="250dp"/>
-
-    <Button
-        android:id="@+id/add_button"
-        android:layout_width="211dp"
-        android:layout_height="63dp"
-        android:layout_marginBottom="64dp"
-        android:text="@string/button_add_amount"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/add_menu.xml
+++ b/app/src/main/res/menu/add_menu.xml
@@ -1,0 +1,7 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/add_menu_button"
+        android:title="@string/button_add_amount"
+        app:showAsAction="always" />
+</menu>


### PR DESCRIPTION
## Description
- Move **Add Amount** Button on the **Add Expense** and **Add Allowance** Screen from the bottom of the screen to the top right in the toolbar
- Closes #7 

## Result
The **Add Amount** Button is no longer visible on the bottom of the **Add Expense** and **Add Allowance** Screen. There is now an **Add Amount** Button on the right side of the top toolbar. The functionality of this button is the same as the previous one.